### PR TITLE
refactor: correct capitalisation for GitHub

### DIFF
--- a/api/backends/github.py
+++ b/api/backends/github.py
@@ -22,11 +22,11 @@ base_url: str = "https://api.github.com"
 
 class GithubRepository(Repository):
     """
-    A repository class that represents a Github repository.
+    A repository class that represents a GitHub repository.
 
     Args:
-        owner (str): The username of the owner of the Github repository.
-        name (str): The name of the Github repository.
+        owner (str): The username of the owner of the GitHub repository.
+        name (str): The name of the GitHub repository.
     """
 
     def __init__(self, owner: str, name: str):
@@ -34,8 +34,8 @@ class GithubRepository(Repository):
         Initializes a new instance of the GithubRepository class.
 
         Args:
-            owner (str): The username of the owner of the Github repository.
-            name (str): The name of the Github repository.
+            owner (str): The username of the owner of the GitHub repository.
+            name (str): The name of the GitHub repository.
         """
         super().__init__(Github())
         self.owner = owner
@@ -44,18 +44,18 @@ class GithubRepository(Repository):
 
 class Github(Backend):
     """
-    A backend class that interacts with the Github API.
+    A backend class that interacts with the GitHub API.
 
     Attributes:
-        name (str): The name of the Github backend.
-        base_url (str): The base URL of the Github API.
-        token (str): The Github access token used for authentication.
-        headers (dict[str, str]): The HTTP headers to be sent with each request to the Github API.
+        name (str): The name of the GitHub backend.
+        base_url (str): The base URL of the GitHub API.
+        token (str): The GitHub access token used for authentication.
+        headers (dict[str, str]): The HTTP headers to be sent with each request to the GitHub API.
     """
 
     def __init__(self):
         """
-        Initializes a new instance of the Github class.
+        Initializes a new instance of the GitHub class.
         """
         super().__init__(repo_name, base_url)
         self.token: Optional[str] = os.getenv("GITHUB_TOKEN")
@@ -121,10 +121,10 @@ class Github(Backend):
         self, repository: GithubRepository, per_page: int = 30, page: int = 1
     ) -> list[Release]:
         """
-        Returns a list of Release objects for a given Github repository.
+        Returns a list of Release objects for a given GitHub repository.
 
         Args:
-            repository (GithubRepository): The Github repository for which to retrieve the releases.
+            repository (GithubRepository): The GitHub repository for which to retrieve the releases.
             per_page (int): The number of releases to return per page.
             page (int): The page number of the releases to return.
 
@@ -148,10 +148,10 @@ class Github(Backend):
         self, repository: GithubRepository, tag_name: str
     ) -> Release:
         """
-        Retrieves a specific release for a given Github repository by its tag name.
+        Retrieves a specific release for a given GitHub repository by its tag name.
 
         Args:
-            repository (GithubRepository): The Github repository for which to retrieve the release.
+            repository (GithubRepository): The GitHub repository for which to retrieve the release.
             tag_name (str): The tag name of the release to retrieve.
 
         Returns:
@@ -171,7 +171,7 @@ class Github(Backend):
         """Get the latest release for a given repository.
 
         Args:
-            repository (GithubRepository): The Github repository for which to retrieve the release.
+            repository (GithubRepository): The GitHub repository for which to retrieve the release.
 
         Returns:
             Release: The latest release for the given repository.
@@ -190,7 +190,7 @@ class Github(Backend):
         """Get the latest pre-release for a given repository.
 
         Args:
-            repository (GithubRepository): The Github repository for which to retrieve the release.
+            repository (GithubRepository): The GitHub repository for which to retrieve the release.
 
         Returns:
             Release: The latest pre-release for the given repository.

--- a/api/compat.py
+++ b/api/compat.py
@@ -2,10 +2,10 @@
 This module provides endpoints for compatibility with the old API.
 
 Routes:
-    - GET /<repo:str>/releases: Retrieve a list of releases for a Github repository.
-    - GET /<repo:str>/releases/latest: Retrieve the latest release for a Github repository.
-    - GET /<repo:str>/releases/tag/<tag:str>: Retrieve a specific release for a Github repository by its tag name.
-    - GET /<repo:str>/contributors: Retrieve a list of contributors for a Github repository.
+    - GET /<repo:str>/releases: Retrieve a list of releases for a GitHub repository.
+    - GET /<repo:str>/releases/latest: Retrieve the latest release for a GitHub repository.
+    - GET /<repo:str>/releases/tag/<tag:str>: Retrieve a specific release for a GitHub repository by its tag name.
+    - GET /<repo:str>/contributors: Retrieve a list of contributors for a GitHub repository.
     - GET /patches/<tag:str>: Retrieve a list of patches for a given release tag.
 
 """
@@ -31,10 +31,10 @@ github_backend: Github = Github()
 )
 async def tools(request: Request) -> JSONResponse:
     """
-    Retrieve a list of releases for a Github repository.
+    Retrieve a list of releases for a GitHub repository.
 
     **Args:**
-        - repo (str): The name of the Github repository to retrieve releases for.
+        - repo (str): The name of the GitHub repository to retrieve releases for.
 
     **Query Parameters:**
         - per_page (int): The number of releases to retrieve per page.
@@ -67,7 +67,7 @@ async def tools(request: Request) -> JSONResponse:
 )
 async def contributors(request: Request) -> JSONResponse:
     """
-    Retrieve a list of releases for a Github repository.
+    Retrieve a list of releases for a GitHub repository.
 
     **Returns:**
         - JSONResponse: A Sanic JSONResponse object containing the list of releases.

--- a/api/github.py
+++ b/api/github.py
@@ -1,11 +1,11 @@
 """
-This module provides endpoints for interacting with the Github API.
+This module provides endpoints for interacting with the GitHub API.
 
 Routes:
-    - GET /<repo:str>/releases: Retrieve a list of releases for a Github repository.
-    - GET /<repo:str>/releases/latest: Retrieve the latest release for a Github repository.
-    - GET /<repo:str>/releases/tag/<tag:str>: Retrieve a specific release for a Github repository by its tag name.
-    - GET /<repo:str>/contributors: Retrieve a list of contributors for a Github repository.
+    - GET /<repo:str>/releases: Retrieve a list of releases for a GitHub repository.
+    - GET /<repo:str>/releases/latest: Retrieve the latest release for a GitHub repository.
+    - GET /<repo:str>/releases/tag/<tag:str>: Retrieve a specific release for a GitHub repository by its tag name.
+    - GET /<repo:str>/contributors: Retrieve a list of contributors for a GitHub repository.
     - GET /patches/<tag:str>: Retrieve a list of patches for a given release tag.
 
 """
@@ -30,10 +30,10 @@ github_backend: Github = Github()
 )
 async def list_releases(request: Request, repo: str) -> JSONResponse:
     """
-    Retrieve a list of releases for a Github repository.
+    Retrieve a list of releases for a GitHub repository.
 
     **Args:**
-        - repo (str): The name of the Github repository to retrieve releases for.
+        - repo (str): The name of the GitHub repository to retrieve releases for.
 
     **Query Parameters:**
         - per_page (int): The number of releases to retrieve per page.
@@ -67,10 +67,10 @@ async def list_releases(request: Request, repo: str) -> JSONResponse:
 )
 async def latest_release(request: Request, repo: str) -> JSONResponse:
     """
-    Retrieve the latest release for a Github repository.
+    Retrieve the latest release for a GitHub repository.
 
     **Args:**
-        - repo (str): The name of the Github repository to retrieve the release for.
+        - repo (str): The name of the GitHub repository to retrieve the release for.
 
     **Query Parameters:**
         - dev (bool): Whether or not to retrieve the latest development release.
@@ -103,17 +103,17 @@ async def latest_release(request: Request, repo: str) -> JSONResponse:
 
 @github.get("/<repo:str>/releases/tag/<tag:str>")
 @openapi.definition(
-    summary="Retrieve a release for a Github repository by its tag name.",
+    summary="Retrieve a release for a GitHub repository by its tag name.",
     response=SingleReleaseResponseModel,
 )
 async def get_release_by_tag_name(
     request: Request, repo: str, tag: str
 ) -> JSONResponse:
     """
-    Retrieve a release for a Github repository by its tag name.
+    Retrieve a release for a GitHub repository by its tag name.
 
     **Args:**
-        - repo (str): The name of the Github repository to retrieve the release for.
+        - repo (str): The name of the GitHub repository to retrieve the release for.
         - tag (str): The tag for the release to be retrieved.
 
     **Returns:**
@@ -142,7 +142,7 @@ async def get_contributors(request: Request, repo: str) -> JSONResponse:
     Retrieve a list of contributors for a repository.
 
     **Args:**
-        - repo (str): The name of the Github repository to retrieve the contributors for.
+        - repo (str): The name of the GitHub repository to retrieve the contributors for.
 
     **Returns:**
         - JSONResponse: A Sanic JSONResponse object containing the list of contributors.

--- a/config.py
+++ b/config.py
@@ -52,7 +52,7 @@ links: list[dict[str, str | bool]] = [
         "preferred": True,
     },
     {
-        "name": "Github Sponsors",
+        "name": "GitHub Sponsors",
         "url": "https://github.com/sponsors/ReVanced",
         "preferred": False,
     },

--- a/qodana.sarif.json
+++ b/qodana.sarif.json
@@ -11288,7 +11288,7 @@
                     "charOffset": 0,
                     "charLength": 72,
                     "snippet": {
-                      "text": "\"\"\"\nThis module provides endpoints for interacting with the Github API.\n"
+                      "text": "\"\"\"\nThis module provides endpoints for interacting with the GitHub API.\n"
                     },
                     "sourceLanguage": "Python"
                   },
@@ -11298,7 +11298,7 @@
                     "charOffset": 0,
                     "charLength": 165,
                     "snippet": {
-                      "text": "\"\"\"\nThis module provides endpoints for interacting with the Github API.\n\nRoutes:\n    - GET /<repo:str>/releases: Retrieve a list of releases for a Github repository."
+                      "text": "\"\"\"\nThis module provides endpoints for interacting with the GitHub API.\n\nRoutes:\n    - GET /<repo:str>/releases: Retrieve a list of releases for a GitHub repository."
                     }
                   }
                 },


### PR DESCRIPTION
### ♨️ Correct capitalisation of GitHub

Previously, we refer to GitHub as "Github" which is incorrect. Changes in this PR are mostly just the docstring.

_What more could I say in this PR to make it look engaging and informative aside from me being irritated by this single mistake. 💀_